### PR TITLE
feature: add locale support to user and subscriber APIs

### DIFF
--- a/src/object_edit.js
+++ b/src/object_edit.js
@@ -37,13 +37,13 @@ export default class ObjectEdit {
     if (!is_empty(this.__info)) {
       const msg = `[object: ${this.object_type}/${
         this.object_id
-      }] ${this.__info.join("\n")}`;
+        }] ${this.__info.join("\n")}`;
       console.log(`WARNING: ${msg}`);
     }
     if (!is_empty(this.__errors)) {
       const msg = `[object: ${this.object_type}/${
         this.object_id
-      }] ${this.__errors.join("\n")}`;
+        }] ${this.__errors.join("\n")}`;
       console.log(`ERROR: ${msg}`);
     }
   }
@@ -201,6 +201,12 @@ export default class ObjectEdit {
   set_preferred_language(lang_code) {
     const caller = "set_preferred_language";
     this._helper._set_preferred_language(lang_code, caller);
+    this._collect_operation();
+  }
+
+  set_locale(locale) {
+    const caller = "set_locale";
+    this._helper._set_locale(locale, caller);
     this._collect_operation();
   }
 

--- a/src/object_edit_internal_helper.js
+++ b/src/object_edit_internal_helper.js
@@ -23,6 +23,7 @@ const IDENT_KEYS_ALL = [
 
 const KEY_ID_PROVIDER = "$id_provider";
 const KEY_PREFERRED_LANGUAGE = "$preferred_language";
+const KEY_LOCALE = "$locale";
 const KEY_TIMEZONE = "$timezone";
 
 export default class _ObjectEditInternalHelper {
@@ -168,6 +169,10 @@ export default class _ObjectEditInternalHelper {
 
   _set_preferred_language(lang_code, caller) {
     this.__dict_set[KEY_PREFERRED_LANGUAGE] = lang_code;
+  }
+
+  _set_locale(locale, caller) {
+    this.__dict_set[KEY_LOCALE] = locale;
   }
 
   _set_timezone(timezone, caller) {

--- a/src/request_json/workflow.json
+++ b/src/request_json/workflow.json
@@ -192,6 +192,10 @@
           "type": ["string", "null"],
           "description": "preferred_language: 2-letter language code in ISO 639-1 Alpha-2 code format. e.g en (for English)"
         },
+        "$locale": {
+          "type": ["string", "null"],
+          "description": "locale: e.g en-US"
+        },
         "$timezone": {
           "type": ["string", "null"],
           "description": "timezone: in IANA timezone format e.g 'America/Los_Angeles'"

--- a/src/request_json/workflow_trigger.json
+++ b/src/request_json/workflow_trigger.json
@@ -187,6 +187,10 @@
           "type": ["string", "null"],
           "description": "preferred_language: 2-letter language code in ISO 639-1 Alpha-2 code format. e.g en (for English)"
         },
+        "$locale": {
+          "type": ["string", "null"],
+          "description": "locale: e.g en-US"
+        },
         "$timezone": {
           "type": ["string", "null"],
           "description": "timezone: in IANA timezone format e.g 'America/Los_Angeles'"

--- a/src/subscriber.js
+++ b/src/subscriber.js
@@ -316,6 +316,12 @@ export class Subscriber {
     this._collect_event();
   }
 
+  set_locale(locale) {
+    const caller = "set_locale";
+    this._helper._set_locale(locale, caller);
+    this._collect_event();
+  }
+
   set_timezone(timezone) {
     const caller = "set_timezone";
     this._helper._set_timezone(timezone, caller);

--- a/src/subscriber_helper.js
+++ b/src/subscriber_helper.js
@@ -23,6 +23,7 @@ const IDENT_KEYS_ALL = [
 
 const KEY_ID_PROVIDER = "$id_provider";
 const KEY_PREFERRED_LANGUAGE = "$preferred_language";
+const KEY_LOCALE = "$locale";
 const KEY_TIMEZONE = "$timezone";
 
 export default class _SubscriberInternalHelper {
@@ -171,6 +172,10 @@ export default class _SubscriberInternalHelper {
 
   _set_preferred_language(lang_code, caller) {
     this.__dict_set[KEY_PREFERRED_LANGUAGE] = lang_code;
+  }
+
+  _set_locale(locale, caller) {
+    this.__dict_set[KEY_LOCALE] = locale;
   }
 
   _set_timezone(timezone, caller) {

--- a/src/user_edit.js
+++ b/src/user_edit.js
@@ -64,7 +64,7 @@ class UserEdit {
     if (apparent_size > IDENTITY_SINGLE_EVENT_MAX_APPARENT_SIZE_IN_BYTES) {
       throw new InputValueError(
         `User Payload size too big - ${apparent_size} Bytes, ` +
-          `must not cross ${IDENTITY_SINGLE_EVENT_MAX_APPARENT_SIZE_IN_BYTES_READABLE}`
+        `must not cross ${IDENTITY_SINGLE_EVENT_MAX_APPARENT_SIZE_IN_BYTES_READABLE}`
       );
     }
     return [payload, apparent_size];
@@ -242,6 +242,13 @@ class UserEdit {
   set_preferred_language(lang_code) {
     const caller = "set_preferred_language";
     this._helper._set_preferred_language(lang_code, caller);
+    this._collect_operation();
+  }
+
+  // ------------------------ Locale
+  set_locale(locale) {
+    const caller = "set_locale";
+    this._helper._set_locale(locale, caller);
     this._collect_operation();
   }
 

--- a/src/user_edit_internal_helper.js
+++ b/src/user_edit_internal_helper.js
@@ -23,6 +23,7 @@ const IDENT_KEYS_ALL = [
 
 const KEY_ID_PROVIDER = "$id_provider";
 const KEY_PREFERRED_LANGUAGE = "$preferred_language";
+const KEY_LOCALE = "$locale";
 const KEY_TIMEZONE = "$timezone";
 
 class _UserEditInternalHelper {
@@ -149,6 +150,10 @@ class _UserEditInternalHelper {
 
   _set_preferred_language(lang_code, caller) {
     this.__dict_set[KEY_PREFERRED_LANGUAGE] = lang_code;
+  }
+
+  _set_locale(locale, caller) {
+    this.__dict_set[KEY_LOCALE] = locale;
   }
 
   _set_timezone(timezone, caller) {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -87,6 +87,7 @@ declare namespace suprsend {
     unset(keys: string | string[]): void;
 
     set_preferred_language(lang_code: string): void;
+    set_locale(locale: string): void;
     set_timezone(timezone: string): void;
 
     add_email(email: string): void;
@@ -333,6 +334,7 @@ declare namespace suprsend {
     unset(keys: string | string[]): void;
 
     set_preferred_language(lang_code: string): void;
+    set_locale(locale: string): void;
     set_timezone(timezone: string): void;
 
     add_email(email: string): void;
@@ -369,6 +371,7 @@ declare namespace suprsend {
     unset(keys: string | string[]): void;
 
     set_preferred_language(lang_code: string): void;
+    set_locale(locale: string): void;
     set_timezone(timezone: string): void;
 
     add_email(email: string): void;


### PR DESCRIPTION
* introduced set_locale method in UserEdit and Subscriber classes
* added _set_locale method in internal helper classes
* updated JSON schemas to include locale field

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added locale configuration support. Users can set a locale (e.g., "en-US") for Subscriber, ObjectEdit, and UserEdit operations via new set_locale() methods. Locale values accept strings or null and are included in user-setting payloads.
* **Style**
  * Minor formatting adjustments to validation/warning message construction (no behavioral changes).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->